### PR TITLE
Add Windows CI and fix tests on windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,7 +95,7 @@ RSpec/DescribedClass:
   EnforcedStyle: explicit
 
 RSpec/ExampleLength:
-  Max: 15
+  Max: 16
 
 RSpec/HookArgument:
   EnforcedStyle: each

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  matrix:
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 21
+
+# Install scripts. (runs after repo cloning)
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle install
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+# Post-install test scripts.
+test_script:
+  - bundle exec rspec
+
+build:
+  off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+# Test on Ruby 2.2 and 2.1
 environment:
   matrix:
     - RUBY_VERSION: 22

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -1,7 +1,7 @@
 require 'digest'
 
 RSpec.describe Percy::Cli::SnapshotRunner do
-  subject(:runner) { Percy::Cli::SnapshotRunner.new }
+  subject(:runner) { described_class.new }
 
   let(:root_dir) { File.expand_path('../testdata/', __FILE__) }
 
@@ -78,17 +78,23 @@ RSpec.describe Percy::Cli::SnapshotRunner do
     it 'returns only the HTML files in the directory' do
       paths = runner._find_root_paths root_dir
 
-      expect(paths).to match_array(
-        [
-          File.join(root_dir, 'index.html'),
-          File.join(root_dir, 'subdir/test.html'),
+      expected_results = [
+        File.join(root_dir, 'index.html'),
+        File.join(root_dir, 'subdir/test.html'),
+      ]
+
+      # Symlinks don't work out-of-the-box upon git clone on windows
+      unless Gem.win_platform?
+        expected_results += [
           # Make sure file symlinks are followed.
           File.join(root_dir, 'subdir/test_symlink.html'),
           # Make sure directory symlinks are followed.
           File.join(root_dir, 'subdir_symlink/test.html'),
           File.join(root_dir, 'subdir_symlink/test_symlink.html'),
-        ],
-      )
+        ]
+      end
+
+      expect(paths).to match_array(expected_results)
     end
   end
 
@@ -96,20 +102,26 @@ RSpec.describe Percy::Cli::SnapshotRunner do
     it 'returns only the related static files in the directory' do
       paths = runner._find_resource_paths root_dir
 
-      expect(paths).to match_array(
-        [
-          File.join(root_dir, 'css/base.css'),
-          File.join(root_dir, 'css/test with spaces.css'),
-          File.join(root_dir, 'images/jellybeans.png'),
-          File.join(root_dir, 'images/large-file-skipped.png'),
+      expected_results = [
+        File.join(root_dir, 'css/base.css'),
+        File.join(root_dir, 'css/test with spaces.css'),
+        File.join(root_dir, 'images/jellybeans.png'),
+        File.join(root_dir, 'images/large-file-skipped.png'),
+      ]
+
+      # Symlinks don't work out-of-the-box upon git clone on windows
+      unless Gem.win_platform?
+        expected_results += [
           # Make sure file symlinks are followed.
           File.join(root_dir, 'images/jellybeans-symlink.png'),
           # Make sure directory symlinks are followed.
           File.join(root_dir, 'images_symlink/jellybeans.png'),
           File.join(root_dir, 'images_symlink/large-file-skipped.png'),
           File.join(root_dir, 'images_symlink/jellybeans-symlink.png'),
-        ],
-      )
+        ]
+      end
+
+      expect(paths).to match_array(expected_results)
     end
   end
 

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -1,7 +1,7 @@
 require 'digest'
 
 RSpec.describe Percy::Cli::SnapshotRunner do
-  subject(:runner) { described_class.new }
+  subject(:runner) { Percy::Cli::SnapshotRunner.new }
 
   let(:root_dir) { File.expand_path('../testdata/', __FILE__) }
 
@@ -81,13 +81,13 @@ RSpec.describe Percy::Cli::SnapshotRunner do
       expected_results = [
         File.join(root_dir, 'index.html'),
         File.join(root_dir, 'subdir/test.html'),
+        # Make sure file symlinks are followed.
+        File.join(root_dir, 'subdir/test_symlink.html'),
       ]
 
-      # Symlinks don't work out-of-the-box upon git clone on windows
+      # Symlinked folders don't work out-of-the-box upon git clone on windows
       unless Gem.win_platform?
         expected_results += [
-          # Make sure file symlinks are followed.
-          File.join(root_dir, 'subdir/test_symlink.html'),
           # Make sure directory symlinks are followed.
           File.join(root_dir, 'subdir_symlink/test.html'),
           File.join(root_dir, 'subdir_symlink/test_symlink.html'),
@@ -107,13 +107,13 @@ RSpec.describe Percy::Cli::SnapshotRunner do
         File.join(root_dir, 'css/test with spaces.css'),
         File.join(root_dir, 'images/jellybeans.png'),
         File.join(root_dir, 'images/large-file-skipped.png'),
+        # Make sure file symlinks are followed.
+        File.join(root_dir, 'images/jellybeans-symlink.png'),
       ]
 
-      # Symlinks don't work out-of-the-box upon git clone on windows
+      # Symlinked folders don't work out-of-the-box upon git clone on windows
       unless Gem.win_platform?
         expected_results += [
-          # Make sure file symlinks are followed.
-          File.join(root_dir, 'images/jellybeans-symlink.png'),
           # Make sure directory symlinks are followed.
           File.join(root_dir, 'images_symlink/jellybeans.png'),
           File.join(root_dir, 'images_symlink/large-file-skipped.png'),


### PR DESCRIPTION
Two tests were failing on Windows.  Symlinked folders don't work out-of-the-box upon git clone on windows, so ignore those when fetching files when specs are running on Windows.