### PR TITLE
pass in ignore_regex option to ignore files from taking a snapshot

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ inherit_gem:
   percy-style:
     - default.yml
 
+AllCops:
+  TargetRubyVersion: 2.1
+
 Style/GlobalVars:
   Exclude:
     - 'lib/percy/cli.rb'

--- a/lib/percy/cli.rb
+++ b/lib/percy/cli.rb
@@ -47,6 +47,10 @@ module Percy
           String,
           'Regular expression for matching the files to snapshot. Defaults to: "\.(html|htm)$"'
         c.option \
+          '--ignore_regex REGEX',
+          String,
+          'Regular expression for matching the files NOT to snapshot. Default is nil.'
+        c.option \
           '--widths CSV',
           String,
           'Comma-separated list of rendering widths for snapshots. Ex: 320,1280"'

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -210,7 +210,7 @@ module Percy
 
       def _include_resource_path?(path, options)
         # Skip git files.
-        return false if path.match?(/\/\.git\//)
+        return false if path =~ /\/\.git\//
         return true if options[:include_all]
 
         STATIC_RESOURCE_EXTENSIONS.include?(File.extname(path))
@@ -228,7 +228,7 @@ module Percy
 
       def _include_root_path?(path, options)
         # Skip git files.
-        return false if path.match?(/\/\.git\//)
+        return false if path =~ /\/\.git\//
 
         # Skip files that don't match the snapshots_regex.
         snapshots_regex = options[:snapshots_regex] || DEFAULT_SNAPSHOTS_REGEX

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -33,6 +33,7 @@ module Percy
         baseurl = options[:baseurl] || '/'
         enable_javascript = !!options[:enable_javascript]
         include_all = !!options[:include_all]
+        ignore_regex = options[:ignore_regex]
         widths = options[:widths].map { |w| Integer(w) }
         raise ArgumentError, 'baseurl must start with /' if baseurl[0] != '/'
 
@@ -40,7 +41,8 @@ module Percy
 
         # Find all the static files in the given root directory.
         root_paths = _find_root_paths(root_dir, snapshots_regex: options[:snapshots_regex])
-        resource_paths = _find_resource_paths(root_dir, include_all: include_all)
+        options = {include_all: include_all, ignore_regex: ignore_regex}
+        resource_paths = _find_resource_paths(root_dir, options)
         root_resources = _list_resources(root_paths, base_resource_options.merge(is_root: true))
         build_resources = _list_resources(resource_paths, base_resource_options)
         all_resources = root_resources + build_resources
@@ -127,7 +129,9 @@ module Percy
       end
 
       def _find_root_paths(dir_path, options = {})
-        _find_files(dir_path).select { |path| _include_root_path?(path, options) }
+        _find_files(dir_path)
+          .select { |path| _include_root_path?(path, options) }
+          .reject { |path| _ignore_resource_path?(path, options) }
       end
 
       def _find_resource_paths(dir_path, options = {})
@@ -210,6 +214,12 @@ module Percy
         return true if options[:include_all]
 
         STATIC_RESOURCE_EXTENSIONS.include?(File.extname(path))
+      end
+
+      def _ignore_resource_path?(path, options)
+        return false unless options[:ignore_regex]
+
+        path.match(options[:ignore_regex]) rescue false
       end
 
       def _include_root_path?(path, options)

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -41,8 +41,8 @@ module Percy
 
         # Find all the static files in the given root directory.
         root_paths = _find_root_paths(root_dir, snapshots_regex: options[:snapshots_regex])
-        options = {include_all: include_all, ignore_regex: ignore_regex}
-        resource_paths = _find_resource_paths(root_dir, options)
+        opts = {include_all: include_all, ignore_regex: ignore_regex}
+        resource_paths = _find_resource_paths(root_dir, opts)
         root_resources = _list_resources(root_paths, base_resource_options.merge(is_root: true))
         build_resources = _list_resources(resource_paths, base_resource_options)
         all_resources = root_resources + build_resources

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -210,7 +210,7 @@ module Percy
 
       def _include_resource_path?(path, options)
         # Skip git files.
-        return false if path =~ /\/\.git\//
+        return false if path.match?(/\/\.git\//)
         return true if options[:include_all]
 
         STATIC_RESOURCE_EXTENSIONS.include?(File.extname(path))
@@ -219,12 +219,16 @@ module Percy
       def _ignore_resource_path?(path, options)
         return false unless options[:ignore_regex]
 
-        path.match(options[:ignore_regex]) rescue false
+        begin
+          path.match(options[:ignore_regex])
+        rescue StandardError
+          false
+        end
       end
 
       def _include_root_path?(path, options)
         # Skip git files.
-        return false if path =~ /\/\.git\//
+        return false if path.match?(/\/\.git\//)
 
         # Skip files that don't match the snapshots_regex.
         snapshots_regex = options[:snapshots_regex] || DEFAULT_SNAPSHOTS_REGEX

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Percy::Cli::SnapshotRunner do
     end
 
     it 'skips files passed into the ignore_regex option' do
-      paths = runner._find_root_paths root_dir, ignore_regex: "skip|ignore"
+      paths = runner._find_root_paths root_dir, ignore_regex: 'skip|ignore'
 
       expected_results = [
         File.join(root_dir, 'index.html'),

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -80,6 +80,30 @@ RSpec.describe Percy::Cli::SnapshotRunner do
 
       expected_results = [
         File.join(root_dir, 'index.html'),
+        File.join(root_dir, 'ignore.html'),
+        File.join(root_dir, 'skip.html'),
+        File.join(root_dir, 'subdir/test.html'),
+        # Make sure file symlinks are followed.
+        File.join(root_dir, 'subdir/test_symlink.html'),
+      ]
+
+      # Symlinked folders don't work out-of-the-box upon git clone on windows
+      unless Gem.win_platform?
+        expected_results += [
+          # Make sure directory symlinks are followed.
+          File.join(root_dir, 'subdir_symlink/test.html'),
+          File.join(root_dir, 'subdir_symlink/test_symlink.html'),
+        ]
+      end
+
+      expect(paths).to match_array(expected_results)
+    end
+
+    it 'skips files passed into the ignore_regex option' do
+      paths = runner._find_root_paths root_dir, ignore_regex: "skip|ignore"
+
+      expected_results = [
+        File.join(root_dir, 'index.html'),
         File.join(root_dir, 'subdir/test.html'),
         # Make sure file symlinks are followed.
         File.join(root_dir, 'subdir/test_symlink.html'),

--- a/spec/percy/cli/testdata/ignore.html
+++ b/spec/percy/cli/testdata/ignore.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+    <h1>Hello World!</h1>
+</html>

--- a/spec/percy/cli/testdata/skip.html
+++ b/spec/percy/cli/testdata/skip.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+    <h1>Hello World!</h1>
+</html>


### PR DESCRIPTION
This adds the ability to pass in the `--ignore_regex` option to ignore certain files from taking a snapshot.

My use case:
I have a static site that is using JavaScript on a page to randomize some seed data. I'd prefer to just skip snapshots on this page entirely.