### PR TITLE
ignore_regex option fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
     - default.yml
 
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 Style/GlobalVars:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1
   - 2.2
   - ruby-head
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
-# Test on Ruby 2.2 and 2.1
+# Test on Ruby 2.2
 environment:
   matrix:
     - RUBY_VERSION: 22
-    - RUBY_VERSION: 21
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -41,10 +41,13 @@ module Percy
         raise ArgumentError, 'baseurl must start with /' if baseurl[0] != '/'
 
         base_resource_options = {strip_prefix: strip_prefix, baseurl: baseurl}
-        opts = {include_all: include_all, ignore_regex: ignore_regex, snapshot_regex: snapshot_regex}
 
         # Find all the static files in the given root directory.
-        opts = {include_all: include_all, ignore_regex: ignore_regex, snapshots_regex: snapshots_regex}
+        opts = {
+          include_all: include_all,
+          ignore_regex: ignore_regex,
+          snapshots_regex: snapshots_regex,
+        }
         root_paths = _find_root_paths(root_dir, opts)
         resource_paths = _find_resource_paths(root_dir, opts)
         root_resources = _list_resources(root_paths, base_resource_options.merge(is_root: true))

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -33,6 +33,7 @@ module Percy
         baseurl = options[:baseurl] || '/'
         enable_javascript = !!options[:enable_javascript]
         include_all = !!options[:include_all]
+        snapshot_regex = options[:snapshot_regex]
         ignore_regex = options[:ignore_regex]
         widths = options[:widths].map { |w| Integer(w) }
         raise ArgumentError, 'baseurl must start with /' if baseurl[0] != '/'
@@ -40,8 +41,8 @@ module Percy
         base_resource_options = {strip_prefix: strip_prefix, baseurl: baseurl}
 
         # Find all the static files in the given root directory.
-        root_paths = _find_root_paths(root_dir, snapshots_regex: options[:snapshots_regex])
-        opts = {include_all: include_all, ignore_regex: ignore_regex}
+        opts = {include_all: include_all, ignore_regex: ignore_regex, snapshot_regex: snapshot_regex}
+        root_paths = _find_root_paths(root_dir, opts)
         resource_paths = _find_resource_paths(root_dir, opts)
         root_resources = _list_resources(root_paths, base_resource_options.merge(is_root: true))
         build_resources = _list_resources(resource_paths, base_resource_options)

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -25,20 +25,23 @@ module Percy
       end
 
       def run(root_dir, options = {})
-        repo = options[:repo] || Percy.config.repo
         root_dir = File.expand_path(File.absolute_path(root_dir))
         strip_prefix = File.expand_path(File.absolute_path(options[:strip_prefix] || root_dir))
-        num_threads = options[:threads] || 10
-        snapshot_limit = options[:snapshot_limit]
-        baseurl = options[:baseurl] || '/'
+
+        # CLI Options
         enable_javascript = !!options[:enable_javascript]
         include_all = !!options[:include_all]
+        snapshot_limit = options[:snapshot_limit]
         snapshots_regex = options[:snapshots_regex]
         ignore_regex = options[:ignore_regex]
         widths = options[:widths].map { |w| Integer(w) }
+        num_threads = options[:threads] || 10
+        repo = options[:repo] || Percy.config.repo
+        baseurl = options[:baseurl] || '/'
         raise ArgumentError, 'baseurl must start with /' if baseurl[0] != '/'
 
         base_resource_options = {strip_prefix: strip_prefix, baseurl: baseurl}
+        opts = {include_all: include_all, ignore_regex: ignore_regex, snapshot_regex: snapshot_regex}
 
         # Find all the static files in the given root directory.
         opts = {include_all: include_all, ignore_regex: ignore_regex, snapshots_regex: snapshots_regex}

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -33,7 +33,7 @@ module Percy
         baseurl = options[:baseurl] || '/'
         enable_javascript = !!options[:enable_javascript]
         include_all = !!options[:include_all]
-        snapshot_regex = options[:snapshot_regex]
+        snapshots_regex = options[:snapshots_regex]
         ignore_regex = options[:ignore_regex]
         widths = options[:widths].map { |w| Integer(w) }
         raise ArgumentError, 'baseurl must start with /' if baseurl[0] != '/'
@@ -41,7 +41,7 @@ module Percy
         base_resource_options = {strip_prefix: strip_prefix, baseurl: baseurl}
 
         # Find all the static files in the given root directory.
-        opts = {include_all: include_all, ignore_regex: ignore_regex, snapshot_regex: snapshot_regex}
+        opts = {include_all: include_all, ignore_regex: ignore_regex, snapshots_regex: snapshots_regex}
         root_paths = _find_root_paths(root_dir, opts)
         resource_paths = _find_resource_paths(root_dir, opts)
         root_resources = _list_resources(root_paths, base_resource_options.merge(is_root: true))

--- a/lib/percy/cli/version.rb
+++ b/lib/percy/cli/version.rb
@@ -1,5 +1,5 @@
 module Percy
   class Cli
-    VERSION = '1.3.0'.freeze
+    VERSION = '1.3.1'.freeze
   end
 end

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -100,11 +100,12 @@ RSpec.describe Percy::Cli::SnapshotRunner do
     end
 
     it 'returns only the files matching the snapshots_regex' do
-      opts = { snapshots_regex: 'htm' }
+      opts = { snapshots_regex: 'xml' }
       paths = runner._find_root_paths(root_dir, opts)
 
       expected_results = [
         File.join(root_dir, 'index.xml'),
+        File.join(root_dir, 'subdir/test.xml'),
       ]
 
       # Symlinked folders don't work out-of-the-box upon git clone on windows

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe Percy::Cli::SnapshotRunner do
       expect(paths).to match_array(expected_results)
     end
 
-    it 'returns only the files matching the snapshot_regex' do
-      opts = { snapshot_regex: 'htm' }
+    it 'returns only the files matching the snapshots_regex' do
+      opts = { snapshots_regex: 'htm' }
       paths = runner._find_root_paths(root_dir, opts)
 
       expected_results = [

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -99,6 +99,25 @@ RSpec.describe Percy::Cli::SnapshotRunner do
       expect(paths).to match_array(expected_results)
     end
 
+    it 'returns only the files matching the snapshot_regex' do
+      opts = { snapshot_regex: 'htm' }
+      paths = runner._find_root_paths(root_dir, opts)
+
+      expected_results = [
+        File.join(root_dir, 'index.xml'),
+      ]
+
+      # Symlinked folders don't work out-of-the-box upon git clone on windows
+      unless Gem.win_platform?
+        expected_results += [
+          # Make sure directory symlinks are followed.
+          File.join(root_dir, 'subdir_symlink/test.xml'),
+        ]
+      end
+
+      expect(paths).to match_array(expected_results)
+    end
+
     it 'skips files passed into the ignore_regex option' do
       opts = { ignore_regex: 'skip|ignore' }
       paths = runner._find_root_paths(root_dir, opts)

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Percy::Cli::SnapshotRunner do
     end
 
     it 'returns only the files matching the snapshots_regex' do
-      opts = { snapshots_regex: 'xml' }
+      opts = {snapshots_regex: 'xml'}
       paths = runner._find_root_paths(root_dir, opts)
 
       expected_results = [
@@ -120,7 +120,7 @@ RSpec.describe Percy::Cli::SnapshotRunner do
     end
 
     it 'skips files passed into the ignore_regex option' do
-      opts = { ignore_regex: 'skip|ignore' }
+      opts = {ignore_regex: 'skip|ignore'}
       paths = runner._find_root_paths(root_dir, opts)
 
       expected_results = [

--- a/spec/percy/cli/snapshot_runner_spec.rb
+++ b/spec/percy/cli/snapshot_runner_spec.rb
@@ -100,7 +100,8 @@ RSpec.describe Percy::Cli::SnapshotRunner do
     end
 
     it 'skips files passed into the ignore_regex option' do
-      paths = runner._find_root_paths root_dir, ignore_regex: 'skip|ignore'
+      opts = { ignore_regex: 'skip|ignore' }
+      paths = runner._find_root_paths(root_dir, opts)
 
       expected_results = [
         File.join(root_dir, 'index.html'),

--- a/spec/percy/cli/testdata/README.md
+++ b/spec/percy/cli/testdata/README.md
@@ -1,0 +1,1 @@
+### This is a readme

--- a/spec/percy/cli/testdata/index.xml
+++ b/spec/percy/cli/testdata/index.xml
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <title>Test Percy CLI</title>
+  <link href="css/base.css" rel="stylesheet" type="text/css">
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+  <link href="//example.com:12345/test-no-protocol.css" rel="stylesheet" type="text/css">
+  <link href='http://example.com:12345/test-single-quotes.css' rel="stylesheet" type="text/css">
+  <link href="http://example.com:12345/test-query-param.css?v=1" rel="stylesheet" type="text/css">
+
+  <link href="http://example.com:12345/test-duplicate.css" rel="stylesheet" type="text/css">
+  <link href="http://example.com:12345/test-duplicate.css" rel="stylesheet" type="text/css">
+
+  <link rel="stylesheet" type="text/css" href="http://example.com:12345/test-diff-tag-order.css">
+
+  <link rel="author" href="https://example.com/should-not-be-included"/>
+
+  <h1>Hello World!</h1>
+
+  Just some text, should not be included:
+  http://example.com/should-not-be-included.css
+</html>

--- a/spec/percy/cli/testdata/subdir/test.xml
+++ b/spec/percy/cli/testdata/subdir/test.xml
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html>Hello World!</html>


### PR DESCRIPTION
This fixes the broken `ignore_regex` option and cleans up the `snapshot_runner` a bit.