### PR TITLE
Update percy-client to v2.0.0

### DIFF
--- a/lib/percy/cli.rb
+++ b/lib/percy/cli.rb
@@ -39,10 +39,6 @@ module Percy
           String,
           'Directory path to strip from generated URLs. Defaults to the given root directory.'
         c.option \
-          '--repo STRING',
-          String,
-          'Full GitHub repo slug (owner/repo-name). Defaults to the local git repo origin URL.'
-        c.option \
           '--snapshots_regex REGEX',
           String,
           'Regular expression for matching the files to snapshot. Defaults to: "\.(html|htm)$"'

--- a/lib/percy/cli/snapshot_runner.rb
+++ b/lib/percy/cli/snapshot_runner.rb
@@ -36,7 +36,6 @@ module Percy
         ignore_regex = options[:ignore_regex]
         widths = options[:widths].map { |w| Integer(w) }
         num_threads = options[:threads] || 10
-        repo = options[:repo] || Percy.config.repo
         baseurl = options[:baseurl] || '/'
         raise ArgumentError, 'baseurl must start with /' if baseurl[0] != '/'
 
@@ -66,7 +65,7 @@ module Percy
         build = _rescue_connection_failures do
           say 'Creating build...'
 
-          build = client.create_build(repo, resources: build_resources)
+          build = client.create_build(resources: build_resources)
 
           say 'Uploading build resources...'
           _upload_missing_resources(build, build, all_resources, num_threads: num_threads)

--- a/percy-cli.gemspec
+++ b/percy-cli.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'commander', '~> 4.3'
-  spec.add_dependency 'percy-client', '~> 1.12'
+  spec.add_dependency 'percy-client', '~> 2.0.0'
   spec.add_dependency 'thread', '~> 0.2'
   spec.add_dependency 'addressable', '~> 2'
 


### PR DESCRIPTION
Updates `percy-client` to 2.0.0 and removes the repo option when `create_build` is called.