### PR TITLE
Update release instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,16 @@
 # Releasing
 
+1. `git checkout master`
+1. `git pull origin master`
+1. `git checkout -b X.X.X`
 1. Update version.rb file accordingly.
-1. Tag the release: `git tag vVERSION`
-1. Push changes: `git push --tags`
+1. Commit and push the version update
 1. Ensure tests have passed on that tag
-1. [Update the release notes](https://github.com/percy/percy-cli/releases) on GitHub
+1. Tag the release: `git tag vX.X.X`
+1. Push changes: `git push --tags`
+1. Open up a pull request titled with the new version number
+1. Merge approved pull request
+1. Draft and publish a [new release on github](https://github.com/percy/percy-cli/releases)
 1. Build and publish:
 
 ```bash


### PR DESCRIPTION
Update release notes to include the new branch-based merge method instead of pushing new versions directly to master.